### PR TITLE
Add /failedbuilds/:lib/:ver bulk read endpoint

### DIFF
--- a/build-logging.js
+++ b/build-logging.js
@@ -203,6 +203,24 @@ class BuildLogging {
         return results;
     }
 
+    async getFailedBuildsForLibrary(library, library_version) {
+        const stmt = await this.connection.prepare(
+            `select compiler, compiler_version, arch, libcxx, compiler_flags, commithash
+                 from latest
+                where library=@library
+                  and library_version=@library_version
+                  and success=0`
+        );
+
+        await stmt.bind({
+            '@library': library,
+            '@library_version': library_version
+        });
+
+        const results = await stmt.all();
+        return results;
+    }
+
     async hasFailedBefore(library, library_version, compiler, compiler_version, arch, libcxx, compiler_flags) {
         const stmt = await this.connection.prepare(
             `select success, commithash

--- a/index.js
+++ b/index.js
@@ -363,6 +363,7 @@ function main() {
                 '/whathasfailedbefore',
                 '/allfailedbuilds',
                 '/gh-commits.js',
+                /^\/failedbuilds\/.*/,
                 /^\/getlogging\/.*/,
                 /^\/getlogging_forcommit\/.*/,
                 /^\/binaries\/.*/,
@@ -664,6 +665,16 @@ function main() {
         })
         .get('/allfailedbuilds', expireshourly, async (req, res) => {
             const builds = await buildlogging.listBuilds();
+            res.send(builds);
+        })
+        .options('/failedbuilds/:library/:library_version', expireshourly, async (req, res) => {
+            res.send();
+        })
+        .get('/failedbuilds/:library/:library_version', expireshourly, async (req, res) => {
+            const builds = await buildlogging.getFailedBuildsForLibrary(
+                req.params.library,
+                req.params.library_version
+            );
             res.send(builds);
         })
         .get('/webfonts/:font', async (req, res) => {


### PR DESCRIPTION
Returns all known-failed combinations for a given `(library, library_version)` pair as a JSON array. Allows the infra library-builder to fetch all failure records in one round-trip instead of POSTing `/hasfailedbefore` per combination, which dominates per-iteration cost after the search-API optimisation in compiler-explorer/infra#2098.

See compiler-explorer/infra#1342 for context.

## Endpoint

`GET /failedbuilds/:library/:library_version` → array of `{compiler, compiler_version, arch, libcxx, compiler_flags, commithash}`, filtered server-side to `success=0`. Includes `commithash` because the C++/Fortran client treats failures from a previous commit as stale.

Auth: unauthed, mirroring the existing `/hasfailedbefore` and `/allfailedbuilds` routes (regex added to the JWT-unless list).

Cache: `expireshourly` middleware, matching the other read failure routes. Client-side invalidation lives in the consumer.

## Why a new endpoint vs. reusing `/allfailedbuilds`

`/allfailedbuilds` calls `listBuilds()`, which dumps the entire `latest` table (all libraries, success and failure). It serves the `/failedbuilds.html` admin page; pulling the whole thing per-builder would be far worse than today's per-iteration POSTs. The new endpoint is scoped to one library/version and one column.

## Verified locally

Drove `BuildLogging.getFailedBuildsForLibrary` directly against a fresh sqlite DB (no full server). Confirmed:

- Returns only rows for the requested `(library, library_version)`.
- Filters out success rows (`setBuildFixed` removed entries don't appear).
- Returns `[]` for an unknown library.
- The existing `hasFailedBefore` still returns the same shape — no regression in the unmodified code path.

## Verify after deploy

- [ ] `curl https://conan.compiler-explorer.com/failedbuilds/boost/1.83.0` returns a JSON array.
- [ ] `curl https://conan.compiler-explorer.com/failedbuilds/nonexistent/v0` returns `[]`.
- [ ] Existing `/hasfailedbefore` POST still returns `{response: bool, ...}`.

## Deployment

```
ce conan reloadwww
ce conan restart
```

Wait ~10s after restart before hitting the proxy.

## Companion infra PR

Will replace per-iteration POSTs with one fetch + in-memory match. Defensive against pre-deploy timing: 404 from this endpoint is treated as "no failures recorded", so worst case we lose the speedup, not correctness.