### PR TITLE
Add (library, library_version) index on latest

### DIFF
--- a/migrations/004-failedbuilds-index.sql
+++ b/migrations/004-failedbuilds-index.sql
@@ -1,0 +1,18 @@
+--------------------------------------------------------------------------------
+-- Up
+--------------------------------------------------------------------------------
+
+-- The PRIMARY KEY on `latest` is (library, compiler, library_version, ...), with
+-- `compiler` sitting between `library` and `library_version`. Lookups by
+-- (library, library_version) -- the new /failedbuilds/:lib/:ver endpoint --
+-- can only use the leading `library` prefix and degrade to a full scan filtered
+-- by library_version. On a 177K-row DB on EBS gp2 that's ~11s cold. This index
+-- makes the lookup O(log n).
+
+CREATE INDEX IF NOT EXISTS idx_latest_lib_ver ON latest(library, library_version);
+
+--------------------------------------------------------------------------------
+-- Down
+--------------------------------------------------------------------------------
+
+DROP INDEX IF EXISTS idx_latest_lib_ver;


### PR DESCRIPTION
The `/failedbuilds/:lib/:ver` endpoint added in #72 takes ~11s on cold cache for popular libraries on the production DB, despite returning only a few KB of JSON. Cause: the `latest` table's primary key is `(library, compiler, library_version, compiler_version, arch, libcxx, compiler_flags)` -- with `compiler` between `library` and `library_version`. Lookups by `(library, library_version)` can only use the leading `library` prefix, so SQLite scans every row for that library and filters by `library_version`. On a 177K-row DB on EBS gp2 that's seconds.

## Live timing (current production)

```
GET /whathasfailedbefore (PK lookup)        86ms
GET /failedbuilds/boost_bin/1.85.0 (cold)   11.4s
GET /failedbuilds/boost_bin/1.85.0 (warm)   130ms
GET /failedbuilds/fmt/10.0.0 (cold lib)     987ms
```

## Verification (local)

Applied the migration to a fresh DB, populated rows, ran `EXPLAIN QUERY PLAN`:

```
SEARCH latest USING INDEX idx_latest_lib_ver (library=? AND library_version=?)
```

vs. (without index):

```
SCAN latest USING PRIMARY KEY (library=?)  -- partial prefix; filters in-memory
```

Existing `hasFailedBefore` PK lookup unchanged (still uses the autoindex).

## Why this matters

This is the missing piece for compiler-explorer/infra#2100 -- the bulk-fetch was supposed to drop ~80s off a boost_bin × popular-compilers-only run, but on the live system the saved per-iteration time is approximately cancelled out by the single 11s cold fetch. Adding the index should bring cold-cache fetches into the milliseconds range.

## Deployment

```
ce conan reloadwww   # pulls new migration file
ce conan restart     # connect() runs pending migrations on startup
```

The migration framework (`sqlite/migrations`) tracks applied migrations in a `migrations` table, so this only runs once. `CREATE INDEX IF NOT EXISTS` is idempotent defence in depth.

After deploy, re-time:

```
curl -s -o /dev/null -w '%{time_total}\n' 'https://conan.compiler-explorer.com/failedbuilds/boost_bin/1.85.0'
```

Expect: well under 1s on cold cache.