### PR TITLE
Covering index for /failedbuilds (replaces idx_latest_lib_ver)

### DIFF
--- a/migrations/005-failedbuilds-covering-index.sql
+++ b/migrations/005-failedbuilds-covering-index.sql
@@ -1,0 +1,31 @@
+--------------------------------------------------------------------------------
+-- Up
+--------------------------------------------------------------------------------
+
+-- /failedbuilds reads (compiler, compiler_version, arch, libcxx,
+-- compiler_flags, commithash) for every row matching (library,
+-- library_version, success=0). The PR #72 index made the lookup fast, but
+-- SQLite still has to read each row from the table to extract those
+-- columns -- and the `latest` table has a large `logging` column (build
+-- log text, often tens of KB) so each row sits in its own page or two.
+-- For boost_bin/1.85.0 (~113 rows) that's ~10MB of mostly-irrelevant log
+-- data per cold query, which on EBS gp2 takes 8-15s.
+--
+-- A covering index that includes all SELECT columns turns the query
+-- index-only: no row reads, no `logging` payload. Index size: ~177K rows
+-- * ~150 bytes = ~26MB, easily cached in RAM.
+--
+-- The previous narrower index is dropped because the new one's leading
+-- prefix (library, library_version) serves the same single-key lookups.
+
+DROP INDEX IF EXISTS idx_latest_lib_ver;
+
+CREATE INDEX IF NOT EXISTS idx_latest_failedbuilds
+    ON latest(library, library_version, success, compiler, compiler_version, arch, libcxx, compiler_flags, commithash);
+
+--------------------------------------------------------------------------------
+-- Down
+--------------------------------------------------------------------------------
+
+DROP INDEX IF EXISTS idx_latest_failedbuilds;
+CREATE INDEX IF NOT EXISTS idx_latest_lib_ver ON latest(library, library_version);


### PR DESCRIPTION
Sister PR to #72 / #74. The `/failedbuilds` endpoint takes 8-15s on cold cache for popular libraries on the production DB, despite the index added in #74. Diagnosis (run on the box):

```
$ ls -lh /home/ce/.conan_server/buildslogs.db
17G

$ time sqlite3 ... 'select count(*) from latest where library="boost_bin" and library_version="1.85.0" and success=0'
113     real    0m0.003s

$ time sqlite3 ... 'select compiler, compiler_version, arch, libcxx, compiler_flags, commithash from latest where library="boost_bin" and library_version="1.85.0" and success=0' > /dev/null
real    0m8.629s
```

`count(*)` (index-only) is 3ms; the actual SELECT is 8.6s. The 17GB DB / 113 rows = ~150KB per row -- mostly the `logging` column. SQLite has to read every matching row's pages just to extract a few small fields.

## Fix

Drop the narrow `(library, library_version)` index, add one that includes all SELECT columns. Query becomes index-only -- no table reads.

Verified locally:

```
EXPLAIN QUERY PLAN
SEARCH latest USING COVERING INDEX idx_latest_failedbuilds
    (library=? AND library_version=? AND success=?)
```

Existing `hasFailedBefore` (PK lookup) unchanged.

## Index size

~177K rows × ~150 bytes = ~26MB. Fits comfortably in the t3a.small's ~1.3GB OS page cache, and is immune to gunicorn churn (the conan recipe/binary I/O doesn't touch this index's pages).

## Deployment

```
ce conan reloadwww   # pulls new migration
ce conan restart     # connect() runs migrate() on startup
```

Building the index on the live 17GB DB will take some time -- expect a longer-than-usual restart while CREATE INDEX scans the table once. Recommend a low-traffic window.

## Companion follow-up (separate PR coming)

The underlying bloat (17GB, mostly old `logging` text) is also worth addressing. A follow-up will extend migration #003 to truncate older log entries; that's quality-of-life on top, not required for this perf fix.