### PR TITLE
Truncate stale logging entries (older than 2025-11-06)

### DIFF
--- a/migrations/006-truncate-stale-logs.sql
+++ b/migrations/006-truncate-stale-logs.sql
@@ -1,0 +1,27 @@
+--------------------------------------------------------------------------------
+-- Up
+--------------------------------------------------------------------------------
+
+-- Migration 003 cleared `logging` for entries older than 2024-01-01. Since
+-- then the DB has grown to ~17GB, dominated by the `logging` text column on
+-- `latest` rows. Anything older than ~6 months is unlikely to be inspected
+-- and the build log retained for it costs disk and per-row read cost
+-- (the latter mostly fixed by the covering index in 005, but the disk space
+-- and table scans elsewhere still benefit).
+--
+-- The cutoff is fixed; build_dt format is YYYYMMDDHHMMSS local time.
+--
+-- Note: this UPDATE doesn't shrink the DB file. Freed page bytes are reused
+-- by future inserts; to reclaim disk space, run VACUUM in a maintenance
+-- window after this migration is deployed (it's not part of the migration
+-- because VACUUM cannot run inside the migration's transaction).
+
+UPDATE latest
+   SET logging = 'Log eliminated due to age'
+ WHERE build_dt < 20251106000000
+   AND logging IS NOT NULL
+   AND logging != 'Log eliminated due to age';
+
+--------------------------------------------------------------------------------
+-- Down
+--------------------------------------------------------------------------------


### PR DESCRIPTION
Mirror of migration #003, more aggressive cutoff. Brings the production DB cleanup current.

## Why

The `latest` table on production is 17GB, dominated by `logging` text (build logs). Migration #003 cleared anything pre-2024; since then we've accumulated about 1GB/month. PR #75's covering index removed the per-query bottleneck, but the disk pressure (and competition for page cache against the 491GB conan-binaries volume) remains.

Cutoff: `20251106000000` — approximately 6 months before today. Logs older than that are unlikely to be inspected.

## What

Single UPDATE migration. Replaces `logging` text with `'Log eliminated due to age'` for matching rows, and skips rows that already have the placeholder (avoids needless rewrites).

## What this does NOT do

The migration only updates row contents. The DB file size doesn't shrink until `VACUUM` is run. That's intentional — `VACUUM` cannot run inside the migration's transaction, and on a 17GB DB it'll take significant wall time and lock writes during. Recommend running it as a separate manual maintenance step after this is deployed:

```bash
# In a low-traffic window, on the conan instance:
sqlite3 /home/ce/.conan_server/buildslogs.db 'VACUUM;'
```

(Or first stop the service to avoid write contention.)

## Verified locally

Inserted 5 rows with various `build_dt` values, ran the migration's UPDATE. Result:

```
old1     dt=20230101  loglen=    25  "Log eliminated due to age"
ancient  dt=20240601  loglen=    25  "Log eliminated due to age"
stale    dt=20251005  loglen=    25  "Log eliminated due to age"
fresh1   dt=20251201  loglen= 16000  "BIG_LOG_CONTENT..."  (untouched)
fresh2   dt=20260301  loglen= 16000  "BIG_LOG_CONTENT..."  (untouched)
```

## Out of scope

A more permanent fix would be to extract `logging` into a sibling table (`latest_logs`), keeping `latest` rows small forever. That requires schema changes plus updates in `build-logging.js` to read/write logs through a JOIN. Worth doing separately if the disk-bloat problem comes back; for now the covering index in #75 means `latest`'s row size doesn't affect query perf.

## Deployment

```
ce conan reloadwww
ce conan restart
```

The UPDATE will run inside the migration transaction during startup. On 17GB it may take a few minutes — a longer-than-usual restart window. Service returns 502 until done.