### PR TITLE
Update deprecated GitHub Actions (checkout, setup-node v2 -> v4)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,9 +19,9 @@ jobs:
         node-version: [16.x, 22.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - run: |


### PR DESCRIPTION
Found by an org-wide [actionlint](https://github.com/rhysd/actionlint) sweep. Per review feedback the lint tooling itself is staying in the core repos (compiler-explorer, infra, compiler-workflows) — this PR keeps just the fixes, which stand on their own:

- actions/checkout v2 -> v4
- actions/setup-node v2 -> v4

🤖 Generated with [Claude Code](https://claude.com/claude-code)